### PR TITLE
Keep manager open when creating new tab

### DIFF
--- a/scripts/src/main.js
+++ b/scripts/src/main.js
@@ -24,17 +24,11 @@ document.addEventListener("DOMContentLoaded", function(e) {
   });
 
   // Add listner for creating tabs
-  chrome.tabs.onCreated.addListener(() => {
-    tabManager.reloadPage();
-  });
-
-  // Add listener for changing tab focus
-  chrome.tabs.onActivated.addListener((activeInfo) => {
-    if (tabManager.managerTab.windowId == activeInfo.windowId) {
+  chrome.tabs.onCreated.addListener((tab) => {
+    if (tab.url.startsWith("chrome-extension://") && tab.url.endsWith("/tabPage.html")){
       chrome.tabs.remove(tabManager.managerTab.id);
-    } else {
-      tabManager.reloadPage();
     }
+    tabManager.reloadPage();
   });
 
   // Add listener for window closing

--- a/scripts/src/tabManager.js
+++ b/scripts/src/tabManager.js
@@ -46,7 +46,6 @@ class TabManager {
           tab.url.hostname = tab.url.hostname.replace(/^www\./,'');
         } else {
           tab.url.hostname = tab.title.replace(/ /g, '_');
-          console.log(tab.title)
         }
 
         let added = false;


### PR DESCRIPTION
The manager tab stays open when creating a new tab or changing the tab focus. Closes #19 