### PR TITLE
Tab limit for tab groups

### DIFF
--- a/scripts/src/tabGroup.js
+++ b/scripts/src/tabGroup.js
@@ -11,9 +11,11 @@ String.prototype.capitalize = function() {
 *   List of tabs to be held by the TabGroup.
 */
 class TabGroup {
+
   constructor(hostname, tabCount, tabs=[]) {
     this.hostname = hostname;
-    this.id = hostname.split('.').join("");
+    // this.id = hostname.split('.').join("");
+    this.id = TabGroup.n_instances++;
     this.tabs = tabs;
     this.tabCount = tabCount;
     this.setTitle();
@@ -27,6 +29,10 @@ class TabGroup {
     }
     if (this.tabCount)
       this.title = "(" + this.tabs.length + ")" + this.title;
+  }
+
+  get nTabs() {
+    return this.tabs.length;
   }
 
   /*
@@ -65,3 +71,5 @@ class TabGroup {
       this.tabs.splice(index, 1);
   }
 }
+
+TabGroup.n_instances = 0;


### PR DESCRIPTION
When tab groups reach a certain limit, a new group of that domain is created. This can be disabled in `settings.limitTabGroupSize`. The max number of tabs is defined in `settings.maxTabsPerGroup`

The `TabGroup.id` attribute has been changed, as it cannot be just a transformation of the `hostname`. For now, it gets and id equal to the number of instances of the class created so far.