### PR TITLE
Some renders in promises and unique IDs for tabgroups and tab containers

### DIFF
--- a/scripts/src/listeners.js
+++ b/scripts/src/listeners.js
@@ -111,7 +111,7 @@ function addListeners(tabManager) {
 
 function addTabListeners(tab, tabManager) {
   // Add event listener to tab
-  $('#' + tab.id + ' .tab').on('click', () => {
+  $('#t-' + tab.id + ' .tab').on('click', () => {
     chrome.windows.update(tab.windowId, {
       focused: true
     });
@@ -133,14 +133,14 @@ function addTabListeners(tab, tabManager) {
   });
 
   // Add event listener for close button
-  $('#' + tab.id + ' .close-tab-btn').on('click', () => {
+  $('#t' + tab.id + ' .close-tab-btn').on('click', () => {
     // Close the selected tab
     chrome.tabs.remove(tab.id);
   });
 }
 
 function addTabGroupListeners(tabGroup, tabManager) {
-  $('#' + tabGroup.id + ' .closeGroupBtn').on('click', () => {
+  $('#tg' + tabGroup.id + ' .closeGroupBtn').on('click', () => {
     for (let i = 0; i < tabGroup.tabs.length; i++) {
       tabGroup.tabs[i].groupID = tabGroup.id;
       chrome.tabs.remove(tabGroup.tabs[i].id);

--- a/scripts/src/renderHTML.js
+++ b/scripts/src/renderHTML.js
@@ -5,14 +5,14 @@ function renderWindow(windowId) {
   `;
 }
 
-function renderWindowTitle(wid, customTitle="") {
+function renderWindowTitle(wid, customTitle = "") {
   let title = customTitle || "Window " + wid;
   return `<h2 class="window-title">${title}</h2>`;
 }
 
 function renderTabGroup(tabGroup, className, favIconUrl) {
   return `
-      <div id="${tabGroup.id}" class="tab-group ${className}">
+      <div id="tg-${tabGroup.id}" class="tab-group ${className}">
       <h1 class="tab-title">${tabGroup.title}
       <img class="icon" src=${favIconUrl} />
       </h1>
@@ -23,7 +23,7 @@ function renderTabGroup(tabGroup, className, favIconUrl) {
 
 function renderTab(tab) {
   return `
-      <div id=${tab.id} class="tabContainer">
+      <div id="t-${tab.id}" class="tabContainer">
       <div class="tab" title=${tab.title}>
       <p class="tabDescription">${tab.title}</p>
       </div>
@@ -61,15 +61,34 @@ function generateTabGroupsByWindow(windows, tabGroups, className, tabCount) {
   $tabGroupContainer.empty();
 
   let tabGroupsByWindow = _.groupBy(tabGroups, (tg) => tg.windowId);
+
   for (let tgs in tabGroupsByWindow) {
     $element = $('#windowWithTabGroups-' + tgs);
     $element.empty();
 
     $element.append(renderWindowTitle(windowIds.indexOf(parseInt(tgs)) + 1));
     $element.append(renderCloseWinBtn());
-    for (let value of tabGroupsByWindow[tgs]) {
-      $element.append(renderTabGroup(value, className, value.tabs[0].favIconUrl));
+
+    function renderThisTabGroup(tg) {
+      return new Promise(function(resolve, reject) {
+        if (!$element.length) {
+          reject();
+        }
+        $element.append(renderTabGroup(tg, className, tg.tabs[0].favIconUrl));
+        resolve();
+      });
     }
+
+    let promisesTabGroups = [];
+    for (let tg of tabGroupsByWindow[tgs]) {
+      promisesTabGroups.push(renderThisTabGroup(tg));
+    }
+
+    Promise.all(promisesTabGroups).then(function() {
+      console.log('All tab groups have been rendered!');
+    }).catch(function() {
+      console.log('Oh no, epic failure!');
+    });
   }
 }
 
@@ -78,8 +97,8 @@ function generateTabGroups(tabGroups, className, tabCount, winSrc, empty = true)
   if (empty) $windowContainer.empty();
   $windowContainer.append(renderWindow(winSrc));
   $tabGroupContainer = $('#windowWithTabGroups-' + winSrc);
-  let title = winSrc == 'all' ? 'All tabs': "Window " + winSrc;
-  $tabGroupContainer.append(renderWindowTitle(0, customTitle=title));
+  let title = winSrc == 'all' ? 'All tabs' : "Window " + winSrc;
+  $tabGroupContainer.append(renderWindowTitle(0, customTitle = title));
   for (let tabGroup of tabGroups) {
     $tabGroupContainer.append(renderTabGroup(tabGroup, className, tabGroup.tabs[0].favIconUrl));
   }
@@ -87,9 +106,27 @@ function generateTabGroups(tabGroups, className, tabCount, winSrc, empty = true)
 
 function generateTabs(tabGroups) {
   for (let tabGroup of tabGroups) {
-    for (let tab of tabGroup.tabs) {
-      $('#' + tabGroup.id).append(renderTab(tab));
+    function renderThisTab(t) {
+      return new Promise(function(resolve, reject) {
+        let $selector = $('#tg-' + tabGroup.id);
+        if (!$selector.length) {
+          reject();
+        }
+        $selector.append(renderTab(t));
+        resolve();
+      });
     }
+
+    let promisesTabs = [];
+    for (let tab of tabGroup.tabs) {
+      promisesTabs.push(renderThisTab(tab));
+    }
+
+    Promise.all(promisesTabs).then(function() {
+      console.log('All tabs have been rendered!');
+    }).catch(function() {
+      console.log('Oh no, epic failure!');
+    });
   }
 }
 


### PR DESCRIPTION
- Added promises to the rendering of the tab groups and the tabs; now, they will be rendered in parallel
- Fixed https://github.com/adamjamesadair/manage-my-tabs/issues/115 by having a different id for tabgroups and for tabs