### PR TITLE
Overscroll main container as a setting

### DIFF
--- a/scripts/src/listeners.js
+++ b/scripts/src/listeners.js
@@ -59,7 +59,7 @@ function addListeners(tabManager) {
 
   // Add listener for tab count settings
 
-  tabManager.storeSettings();
+  tabManager.addGenericSettingsCallbacks();
 
   // Add listener for layout options
   $(".layout-option").each(function() {

--- a/scripts/src/renderHTML.js
+++ b/scripts/src/renderHTML.js
@@ -90,7 +90,7 @@ function generateTabGroupsByWindow(windows, tabGroups, className, tabCount) {
     }
 
     Promise.all(promisesTabGroups).then(function() {
-      console.log('All tab groups have been rendered!');
+      // console.log('All tab groups have been rendered!');
     }).catch(function() {
       console.log('Oh no, epic failure!');
     });
@@ -129,7 +129,7 @@ function generateTabs(tabGroups) {
     }
 
     Promise.all(promisesTabs).then(function() {
-      console.log('All tabs have been rendered!');
+      // console.log('All tabs have been rendered!');
     }).catch(function() {
       console.log('Oh no, epic failure!');
     });

--- a/scripts/src/tabManager.js
+++ b/scripts/src/tabManager.js
@@ -7,7 +7,7 @@ class TabManager {
     this.windows = [];
     this.currentWin = {};
     this.settings = {};
-    this.settingsIds = ['classicMode', 'closeManagerWhenTabSelected', 'limitTabGroupSize', 'maxTabsPerGroup', 'sortMethod', 'searchScope', 'winSrc', 'tabCount', 'includeManager', 'col'];
+    this.settingsIds = ['allowOverscrollMainContainer', 'classicMode', 'closeManagerWhenTabSelected', 'limitTabGroupSize', 'maxTabsPerGroup', 'sortMethod', 'searchScope', 'winSrc', 'tabCount', 'includeManager', 'col'];
   }
 
   reloadPage() {
@@ -69,7 +69,7 @@ class TabManager {
       generateWindows(tabGroups);
       if (this.windows.length > 1) {
         $('.window-container').css({
-          'padding-bottom': '53vh'
+          'padding-bottom': this.settings.allowOverscrollMainContainer ? '53vh' : '0vh' 
         });
       }
       generateTabGroupsByWindow(this.windows, tabGroups, 'col-' + this.settings['col'], this.settings['tabCount']);
@@ -134,7 +134,7 @@ class TabManager {
     }
   }
 
-  storeSettings() {
+  addGenericSettingsCallbacks() {
     for (let setting of this.settingsIds) {
       let $settingSelector = $("#" + setting);
       let type = $settingSelector.prop("type");
@@ -381,6 +381,7 @@ function arrangeWindowTabs(win) {
 }
 
 var defaultSettings = {
+  allowOverscrollMainContainer: false,
   classicMode: false,
   searchScope: "both",
   sortMethod: "alphabetically",

--- a/tabPage.html
+++ b/tabPage.html
@@ -130,6 +130,13 @@
           <span class="slider"></span>
         </label>
       </div>
+      <div class="overscroll-main-container">
+        <h3>Allow scrolling beyond the end of the last window:</h3>
+        <label class="switch">
+          <input type="checkbox" id="allowOverscrollMainContainer">
+          <span class="slider"></span>
+        </label>
+      </div>
       <div class="restore-defaults">
         <button id="restore-Btn">Restore Defaults</button>
       </div>


### PR DESCRIPTION
- Added `'allowOverscrollMainContainer'` as a generic setting and solved this issue: https://github.com/adamjamesadair/manage-my-tabs/issues/119
- Removed `console.log` from rendering promises
- Renamed `tabManager.storeSettings` to `tabManager.addGenericSettingsCallbacks`