### PR TITLE
Removed max height for tab groups

### DIFF
--- a/scripts/src/listeners.js
+++ b/scripts/src/listeners.js
@@ -181,7 +181,6 @@ function addTabOptionListeners(tab, tabManager) {
   // Add event listener for tab options button
   $('#t-' + tab.id + ' .tab-options-btn').on('click', () => {
     $('#t-' + tab.id + ' .dropdown-content').addClass('active');
-    $('#' + tab.tabGroupID).css('overflow', 'visible');
   });
 
   // Close dropdown on mouse leave

--- a/styles/src/tabGroups.css
+++ b/styles/src/tabGroups.css
@@ -7,8 +7,7 @@
   border: 1px solid black;
   padding-bottom: 0.5rem;
   background-color: var(--tab-group-bg-color);
-  max-height: 11rem;
-  overflow-y: auto;
+  overflow-y: visible;
 }
 
 .tab-group:hover .closeGroupBtn, .tab-group:hover .tab-group-options-btn {


### PR DESCRIPTION
Removed the max height for tab groups. This makes a better appearance than scrolling. Fixes #148.