### PR TITLE
Fixed manager reloading on title update

### DIFF
--- a/scripts/src/listeners.js
+++ b/scripts/src/listeners.js
@@ -49,7 +49,13 @@ function addListeners(tabManager) {
         chrome.tabs.remove(tabManager.managerTab.id);
       }
     }
-    tabManager.reloadPage();
+
+    if (changeInfo['url']) {
+      tabManager.reloadPage();
+    } else if (changeInfo['title']) {
+      $('#t-' + tab.id).empty();
+      $('#t-' + tab.id).append(renderTabContent(tab));
+    }
   });
 
   // Add listner for tabs being removed

--- a/scripts/src/renderHTML.js
+++ b/scripts/src/renderHTML.js
@@ -27,6 +27,12 @@ function renderTabGroup(tabGroup, className, favIconUrl) {
 }
 
 function renderTab(tab) {
+
+  return `<div id="t-${tab.id}" class="tabContainer">`.concat(renderTabContent(tab))
+    .concat(`</div>`);
+}
+
+function renderTabContent(tab) {
   options = [{
     id: 'reload',
     text: 'Reload'
@@ -37,13 +43,11 @@ function renderTab(tab) {
     id: 'merge',
     text: 'Merge with Window'
   }];
-  return `
-      <div id="t-${tab.id}" class="tabContainer">
-        <div class="tab" title=${tab.title}>
-          <p class="tabDescription">${tab.title}</p>
-        </div>
-        <div class="close-tab-btn close-btn">X</div>`
-    .concat(renderDropdownOptions('tab-options-btn', options)).concat(`</div>`);
+  return `<div class="tab" title=${tab.title}>
+            <p class="tabDescription">${tab.title}</p>
+          </div>
+          <div class="close-tab-btn close-btn">X</div>`
+    .concat(renderDropdownOptions('tab-options-btn', options));
 }
 
 function renderDropdownOptions(className, options) {


### PR DESCRIPTION
The Manager now reloads only when the url is changed. When the title changes, just the html of that tab is updated. Closes #154.